### PR TITLE
Fix Type error in generated code.

### DIFF
--- a/src/generator/DAOFileGenerator.php
+++ b/src/generator/DAOFileGenerator.php
@@ -395,7 +395,7 @@ class DAOFileGenerator
 		$this->addLine("}", 2);
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "04 Delete record from table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "04 Delete record from table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);
@@ -445,7 +445,7 @@ class DAOFileGenerator
 		$this->addLine("}", 2);
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "07 Read record from table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "07 Read record from table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);
@@ -518,7 +518,7 @@ class DAOFileGenerator
 		$this->addLine("}", 2);
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "03 Update record in table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "03 Update record in table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);
@@ -610,7 +610,7 @@ class DAOFileGenerator
 		$this->addLine("}", 2);
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "02 Insert record into table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "02 Insert record into table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);

--- a/src/generator/MySQLDAOFileGenerator.php
+++ b/src/generator/MySQLDAOFileGenerator.php
@@ -72,7 +72,7 @@ class MySQLDAOFileGenerator extends DAOFileGenerator
 		$this->addLine("}", 2);
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "03 Update record in table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "03 Update record in table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);
@@ -146,7 +146,7 @@ class MySQLDAOFileGenerator extends DAOFileGenerator
 		$this->addLine("}", 2);
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "02 Insert record into table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "02 Insert record into table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);

--- a/src/generator/PostgreDAOFileGenerator.php
+++ b/src/generator/PostgreDAOFileGenerator.php
@@ -54,7 +54,7 @@ class PostgreDAOFileGenerator extends DAOFileGenerator
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
 		$this->addLine("\$db->rollback();", 3);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "04 Delete record from table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "04 Delete record from table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -------------------------------------------------------------------------", 1);
@@ -108,7 +108,7 @@ class PostgreDAOFileGenerator extends DAOFileGenerator
 		$this->addLine("}", 2);
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "07 Read record from table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "07 Read record from table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);
@@ -188,7 +188,7 @@ class PostgreDAOFileGenerator extends DAOFileGenerator
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
 		$this->addLine("\$db->rollback();", 3);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "03 Update record in table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "03 Update record in table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);
@@ -278,7 +278,7 @@ class PostgreDAOFileGenerator extends DAOFileGenerator
 		$this->addLine("else", 2);
 		$this->addLine("{", 2);
 		$this->addLine("\$db->rollback();", 3);
-		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$this, \"" . $t->getErrorPrefix() . "02 Insert record into table " . $t->getName() . " fail\");", 3);
+		$this->addLine("throw new \\braga\\db\\exception\\ExecutionSqlException(\$db, \"" . $t->getErrorPrefix() . "02 Insert record into table " . $t->getName() . " fail\");", 3);
 		$this->addLine("}", 2);
 		$this->addLine("}", 1);
 		$this->addLine("// -----------------------------------------------------------------------------------------------------------------", 1);


### PR DESCRIPTION
Usunięto spację (Visual Code) co nie wpływa na kod, dla tego są dużo zmian.

Generalnie przy `throw new \\braga\\db\\exception\\ExecutionSqlException` był `$this` co jest instancja `braga\db\DAO`, a według `\braga\db\exception\ExecutionSqlException` muszę być `braga\db\DataSource`.
